### PR TITLE
Add MacOS executable to supported formats

### DIFF
--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -2,7 +2,7 @@ name: TriageSandbox
 version: $SERVICE_TAG
 description: Provides dynamic malware analysis through sandboxing.
 
-accepts: (executable/(windows|linux)|java|audiovisual|meta)/.*|document/(installer/windows|office/(excel|ole|powerpoint|rtf|unknown|word|mhtml|onenote)|pdf$)|code/(javascript|jscript|python|vbs|wsf|html|ps1|batch|hta|vbe|a3x)|shortcut/windows|archive/(chm|iso|rar|vhd|udf|zip|7-zip)|text/windows/registry|audiovisual/flash
+accepts: (executable/(windows|linux)|java|audiovisual|meta)/.*|document/(installer/windows|office/(excel|ole|powerpoint|rtf|unknown|word|mhtml|onenote)|pdf$)|code/(javascript|jscript|python|vbs|wsf|html|ps1|batch|hta|vbe|a3x)|shortcut/windows|archive/(chm|iso|rar|vhd|udf|zip|7-zip)|text/windows/registry|audiovisual/flash|executable/mach-o
 rejects: empty|metadata/.*
 
 stage: CORE


### PR DESCRIPTION
Tria.ge sandbox is capable of analysing MacOS / OS X executables

The format I see in my AL instance is `executable/mach-o` without any third part in the format, so I put it as a separated match.