### PR TITLE
Adding fix for Triage returning the unexpected build field in response that caused an exception in the service.

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -444,12 +444,24 @@ class Sample:
         self.task_reports = []
         for task in self.tasks:
             if task['id'].startswith("behavioral") and task['status'] != "failed":
+                # Get the API response
+                api_response = client._req_json(
+                    method="GET",
+                    path=f"/v0/samples/{self.id}/{task['id']}/report_triage.json"
+                )
+                
+                # Filter out any fields that DynamicReport doesn't expect
+                # Keep only the fields that are defined in the DynamicReport class
+                expected_fields = {
+                    'version', 'sample', 'task', 'analysis', 'signatures', 
+                    'network', 'processes', 'extracted', 'tags', 'dumped', 'errors'
+                }
+                filtered_response = {k: v for k, v in api_response.items() if k in expected_fields}
+                
                 self.task_reports.append(DynamicReport(
                     task_id=task['id'],
-                    ontology=ontology, **client._req_json(
-                        method="GET",
-                        path=f"/v0/samples/{self.id}/{task['id']}/report_triage.json"
-                    )
+                    ontology=ontology, 
+                    **filtered_response
                 )
                 )
         pass

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -24,7 +24,7 @@ config:
   # root_url: https://private.tria.ge/api
 
   # Add your API key here
-  # api_key: null
+  api_key: ""
 
   allow_dynamic_submit: true # Set to false if you don't want to submit files.
 


### PR DESCRIPTION
I was getting the exception:
```
  File "/var/lib/assemblyline/.local/lib/python3.11/site-packages/assemblyline_v4_service/common/base.py", line 180, in handle_task
    self.execute(request)
  File "/opt/al_service/service.py", line 176, in execute
    triage_result = TriageResult(self.client, self.client.sample_by_id(sample_id=submission["id"]))
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/al_service/helper.py", line 464, in __init__
    self.sample.get_task_reports(client, ontology=OntologyResults(service_name=SERVICE_NAME))
  File "/opt/al_service/helper.py", line 447, in get_task_reports
    self.task_reports.append(DynamicReport(
                             ^^^^^^^^^^^^^^
TypeError: DynamicReport.__init__() got an unexpected keyword argument 'build'
```
It looks like Triage added this to their response, so we need to handle this and any future changes as well. We can just add `build` to the dataclass if that's preferred.

I also wanted to enable the `api_key` to the config, so that it can be used in addition to the `submission_params`. This allows a submission to be done without exposing the API key in the UI.