### PR TITLE
Add HTTP and DNS details to network connection reports

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -236,7 +236,12 @@ class DynamicReport:
         for header in headers or []:
             if ":" in header:
                 key, value = header.split(":", 1)
-                values[key.strip()] = value.strip()
+                key = key.strip()
+                value = value.strip()
+                if key in values:
+                    values[key] = f"{values[key]}, {value}"
+                else:
+                    values[key] = value
         return values
 
     @staticmethod

--- a/helper.py
+++ b/helper.py
@@ -236,7 +236,7 @@ class DynamicReport:
         for header in headers or []:
             if ":" in header:
                 key, value = header.split(":", 1)
-                key = key.strip()
+                key = key.strip().lower()
                 value = value.strip()
                 if key in values:
                     values[key] = f"{values[key]}, {value}"
@@ -248,6 +248,25 @@ class DynamicReport:
     def __normalize_dns_lookup_type(lookup_type: str) -> str:
         # Triage returns values like "IN A", while ontology expects just "A".
         return lookup_type.split(" ")[-1].strip().upper()
+
+    @staticmethod
+    def __extract_resolved_domains_from_answers(answers: Optional[List[dict]]) -> List[str]:
+        resolved_domains = []
+        for answer in answers or []:
+            value = answer.get("value")
+            if not isinstance(value, str):
+                continue
+            value = value.strip()
+            if not value:
+                continue
+            try:
+                ip_address(value)
+                continue
+            except ValueError:
+                pass
+            if value not in resolved_domains:
+                resolved_domains.append(value)
+        return resolved_domains
 
     def __add_processes(self) -> None:
         self._id_pid_map = {}
@@ -286,19 +305,34 @@ class DynamicReport:
                 flow_id = request.get("flow", None)
                 if flow_id is None:
                     continue
-                network_requests.setdefault(flow_id, {})
+                flow_requests = network_requests.setdefault(flow_id, {"dns_events": [], "dns_events_by_index": {}})
                 if request.get("http_request", None):
-                    network_requests[flow_id]["http_request"] = request["http_request"]
+                    flow_requests["http_request"] = request["http_request"]
                 if request.get("http_response", None):
-                    network_requests[flow_id]["http_response"] = request["http_response"]
+                    flow_requests["http_response"] = request["http_response"]
                 if request.get("dns_request", None):
-                    network_requests[flow_id]["dns_request"] = request["dns_request"]
+                    flow_requests["dns_request"] = request["dns_request"]
                 if request.get("dns_response", None):
-                    network_requests[flow_id]["dns_response"] = request["dns_response"]
+                    flow_requests["dns_response"] = request["dns_response"]
+                if request.get("dns_request", None) or request.get("dns_response", None):
+                    request_index = request.get("index", None)
+                    if request_index is not None:
+                        dns_event = flow_requests["dns_events_by_index"].get(request_index, None)
+                        if dns_event is None:
+                            dns_event = {}
+                            flow_requests["dns_events_by_index"][request_index] = dns_event
+                            flow_requests["dns_events"].append(dns_event)
+                    else:
+                        dns_event = {}
+                        flow_requests["dns_events"].append(dns_event)
+                    if request.get("dns_request", None):
+                        dns_event["dns_request"] = request["dns_request"]
+                    if request.get("dns_response", None):
+                        dns_event["dns_response"] = request["dns_response"]
 
-            self.flow_dict = {}
+            flow_connection_payloads = []
             for f in self.network.get("flows", []):
-                self.flow_dict[f['id']] = {
+                base_flow = {
                     "destination_ip": f["dst"].split(":")[0],
                     "destination_port": int(f["dst"].split(":")[1]),
                     "transport_layer_protocol": f["proto"],
@@ -311,14 +345,14 @@ class DynamicReport:
                         else self.start_time.strftime("%Y-%m-%d %H:%M:%S.%f")
                     ][0]
                 }
-                if f.get("pid", False):
-                    pass
 
                 flow_id = f["id"]
                 flow_request = network_requests.get(flow_id, {})
                 protocols = f.get("protocols", [])
+                flow_payloads = []
                 if flow_request.get("http_request", None) or any(proto.startswith("http") for proto in protocols):
-                    self.flow_dict[flow_id]["connection_type"] = "http"
+                    flow_payload = base_flow.copy()
+                    flow_payload["connection_type"] = "http"
                     http_request = flow_request.get("http_request", {})
                     http_response = flow_request.get("http_response", {})
                     request_uri = http_request.get("url", None)
@@ -336,34 +370,71 @@ class DynamicReport:
                             http_details["response_status_code"] = int(http_response["status"])
                         if http_response.get("response", None):
                             http_details["response_body"] = http_response["response"]
-                        self.flow_dict[flow_id]["http_details"] = http_details
+                        flow_payload["http_details"] = http_details
+                    flow_payloads.append(flow_payload)
                 elif flow_request.get("dns_request", None) or any(proto == "dns" for proto in protocols):
-                    self.flow_dict[flow_id]["connection_type"] = "dns"
-                    dns_request = flow_request.get("dns_request", {})
-                    dns_response = flow_request.get("dns_response", {})
-                    domain = (dns_request.get("domains", [None]) or [None])[0] or f.get("domain", None)
-                    questions = dns_request.get("questions", [])
-                    lookup_type = None
-                    if questions:
-                        lookup_type = self.__normalize_dns_lookup_type(questions[0].get("type", ""))
-                    if domain and lookup_type:
-                        dns_details = {
-                            "domain": domain,
-                            "lookup_type": lookup_type
-                        }
-                        if dns_response.get("ip", None):
-                            dns_details["resolved_ips"] = dns_response["ip"]
-                        if dns_response.get("domains", None):
-                            dns_details["resolved_domains"] = dns_response["domains"]
-                        self.flow_dict[flow_id]["dns_details"] = dns_details
+                    dns_events = flow_request.get("dns_events", [])
+                    if dns_events:
+                        for dns_event in dns_events:
+                            flow_payload = base_flow.copy()
+                            flow_payload["connection_type"] = "dns"
+                            dns_request = dns_event.get("dns_request", {})
+                            dns_response = dns_event.get("dns_response", {})
+                            domain = (dns_request.get("domains", [None]) or [None])[0] or f.get("domain", None)
+                            questions = dns_request.get("questions", [])
+                            lookup_type = None
+                            if questions:
+                                lookup_type = self.__normalize_dns_lookup_type(questions[0].get("type", ""))
+                            if domain and lookup_type:
+                                dns_details = {
+                                    "domain": domain,
+                                    "lookup_type": lookup_type
+                                }
+                                if dns_response.get("ip", None):
+                                    dns_details["resolved_ips"] = dns_response["ip"]
+                                resolved_domains = self.__extract_resolved_domains_from_answers(
+                                    dns_response.get("answers", [])
+                                )
+                                if resolved_domains:
+                                    dns_details["resolved_domains"] = resolved_domains
+                                flow_payload["dns_details"] = dns_details
+                            flow_payloads.append(flow_payload)
+                    else:
+                        flow_payload = base_flow.copy()
+                        flow_payload["connection_type"] = "dns"
+                        dns_request = flow_request.get("dns_request", {})
+                        dns_response = flow_request.get("dns_response", {})
+                        domain = (dns_request.get("domains", [None]) or [None])[0] or f.get("domain", None)
+                        questions = dns_request.get("questions", [])
+                        lookup_type = None
+                        if questions:
+                            lookup_type = self.__normalize_dns_lookup_type(questions[0].get("type", ""))
+                        if domain and lookup_type:
+                            dns_details = {
+                                "domain": domain,
+                                "lookup_type": lookup_type
+                            }
+                            if dns_response.get("ip", None):
+                                dns_details["resolved_ips"] = dns_response["ip"]
+                            resolved_domains = self.__extract_resolved_domains_from_answers(
+                                dns_response.get("answers", [])
+                            )
+                            if resolved_domains:
+                                dns_details["resolved_domains"] = resolved_domains
+                            flow_payload["dns_details"] = dns_details
+                        flow_payloads.append(flow_payload)
+                else:
+                    flow_payloads.append(base_flow.copy())
 
-                if ip_address(self.flow_dict[f["id"]]["source_ip"]).is_private and ip_address(
-                        self.flow_dict[f["id"]]["destination_ip"]).is_global:
-                    self.flow_dict[f["id"]]["direction"] = "outbound"
-                if f.get("pid", None):
-                    self.flow_dict[f["id"]]["process"] = self.ontology.get_process_by_pid(
-                        f["pid"])
-            for k, v in self.flow_dict.items():
+                for flow_payload in flow_payloads:
+                    if ip_address(flow_payload["source_ip"]).is_private and ip_address(
+                            flow_payload["destination_ip"]).is_global:
+                        flow_payload["direction"] = "outbound"
+                    if f.get("pid", None):
+                        flow_payload["process"] = self.ontology.get_process_by_pid(f["pid"])
+                    flow_connection_payloads.append(flow_payload)
+
+            for v in flow_connection_payloads:
                 oid = NetworkConnectionModel.get_oid(v)
                 tag = NetworkConnectionModel.get_tag(v)
                 object_id = self.ontology.create_objectid(
@@ -372,8 +443,8 @@ class DynamicReport:
                     session=self.session,
                     **v)
                 object_id.assign_guid()
-                v.pop("time_observed", None)
                 network_connection_args = v.copy()
+                network_connection_args.pop("time_observed", None)
                 dns_details = network_connection_args.get("dns_details")
                 if dns_details:
                     network_connection_args["dns_details"] = NetworkDNS(

--- a/helper.py
+++ b/helper.py
@@ -14,6 +14,8 @@ from assemblyline.odm.models.ontology.results.sandbox import Sandbox as SandboxM
 from assemblyline_service_utilities.common.dynamic_service_helper import (
     Attribute,
     NetworkConnection,
+    NetworkDNS,
+    NetworkHTTP,
     OntologyResults,
     Process,
     Sandbox,
@@ -228,6 +230,20 @@ class DynamicReport:
     def __relative_time_str(self, seconds: int) -> str:
         return (self.start_time + timedelta(seconds=seconds)).strftime("%Y-%m-%d %H:%M:%S.%f")
 
+    @staticmethod
+    def __headers_list_to_dict(headers: Optional[List[str]]) -> dict:
+        values = {}
+        for header in headers or []:
+            if ":" in header:
+                key, value = header.split(":", 1)
+                values[key.strip()] = value.strip()
+        return values
+
+    @staticmethod
+    def __normalize_dns_lookup_type(lookup_type: str) -> str:
+        # Triage returns values like "IN A", while ontology expects just "A".
+        return lookup_type.split(" ")[-1].strip().upper()
+
     def __add_processes(self) -> None:
         self._id_pid_map = {}
         for process in self.processes:
@@ -260,6 +276,21 @@ class DynamicReport:
 
     def __add_network(self) -> None:
         if self.network:
+            network_requests = {}
+            for request in self.network.get("requests", []):
+                flow_id = request.get("flow", None)
+                if flow_id is None:
+                    continue
+                network_requests.setdefault(flow_id, {})
+                if request.get("http_request", None):
+                    network_requests[flow_id]["http_request"] = request["http_request"]
+                if request.get("http_response", None):
+                    network_requests[flow_id]["http_response"] = request["http_response"]
+                if request.get("dns_request", None):
+                    network_requests[flow_id]["dns_request"] = request["dns_request"]
+                if request.get("dns_response", None):
+                    network_requests[flow_id]["dns_response"] = request["dns_response"]
+
             self.flow_dict = {}
             for f in self.network.get("flows", []):
                 self.flow_dict[f['id']] = {
@@ -277,11 +308,50 @@ class DynamicReport:
                 }
                 if f.get("pid", False):
                     pass
-                # TODO: #1 add connection details
-                # if any(proto.startswith("http") for proto in f["protocols"]):
-                #     self.flow_dict[f["id"]]["connection_type"] = "http"
-                # elif any(proto == "dns" for proto in f["protocols"]):
-                #     self.flow_dict[f["id"]]["connection_type"] = "dns"
+
+                flow_id = f["id"]
+                flow_request = network_requests.get(flow_id, {})
+                protocols = f.get("protocols", [])
+                if flow_request.get("http_request", None) or any(proto.startswith("http") for proto in protocols):
+                    self.flow_dict[flow_id]["connection_type"] = "http"
+                    http_request = flow_request.get("http_request", {})
+                    http_response = flow_request.get("http_response", {})
+                    request_uri = http_request.get("url", None)
+                    request_method = http_request.get("method", None)
+                    if request_uri and request_method:
+                        http_details = {
+                            "request_uri": request_uri,
+                            "request_method": request_method.upper(),
+                            "request_headers": self.__headers_list_to_dict(http_request.get("headers", [])),
+                            "response_headers": self.__headers_list_to_dict(http_response.get("headers", [])),
+                        }
+                        if http_request.get("request", None):
+                            http_details["request_body"] = http_request["request"]
+                        if http_response.get("status", None):
+                            http_details["response_status_code"] = int(http_response["status"])
+                        if http_response.get("response", None):
+                            http_details["response_body"] = http_response["response"]
+                        self.flow_dict[flow_id]["http_details"] = http_details
+                elif flow_request.get("dns_request", None) or any(proto == "dns" for proto in protocols):
+                    self.flow_dict[flow_id]["connection_type"] = "dns"
+                    dns_request = flow_request.get("dns_request", {})
+                    dns_response = flow_request.get("dns_response", {})
+                    domain = (dns_request.get("domains", [None]) or [None])[0] or f.get("domain", None)
+                    questions = dns_request.get("questions", [])
+                    lookup_type = None
+                    if questions:
+                        lookup_type = self.__normalize_dns_lookup_type(questions[0].get("type", ""))
+                    if domain and lookup_type:
+                        dns_details = {
+                            "domain": domain,
+                            "lookup_type": lookup_type
+                        }
+                        if dns_response.get("ip", None):
+                            dns_details["resolved_ips"] = dns_response["ip"]
+                        if dns_response.get("domains", None):
+                            dns_details["resolved_domains"] = dns_response["domains"]
+                        self.flow_dict[flow_id]["dns_details"] = dns_details
+
                 if ip_address(self.flow_dict[f["id"]]["source_ip"]).is_private and ip_address(
                         self.flow_dict[f["id"]]["destination_ip"]).is_global:
                     self.flow_dict[f["id"]]["direction"] = "outbound"
@@ -298,10 +368,32 @@ class DynamicReport:
                     **v)
                 object_id.assign_guid()
                 v.pop("time_observed", None)
+                network_connection_args = v.copy()
+                dns_details = network_connection_args.get("dns_details")
+                if dns_details:
+                    network_connection_args["dns_details"] = NetworkDNS(
+                        domain=dns_details["domain"],
+                        resolved_ips=dns_details.get("resolved_ips"),
+                        resolved_domains=dns_details.get("resolved_domains"),
+                        lookup_type=dns_details["lookup_type"],
+                    )
+                http_details = network_connection_args.get("http_details")
+                if http_details:
+                    request_headers = http_details.get("request_headers") or None
+                    response_headers = http_details.get("response_headers") or None
+                    network_connection_args["http_details"] = NetworkHTTP(
+                        request_uri=http_details["request_uri"],
+                        request_method=http_details["request_method"],
+                        request_headers=request_headers,
+                        response_headers=response_headers,
+                        request_body=http_details.get("request_body"),
+                        response_status_code=http_details.get("response_status_code"),
+                        response_body=http_details.get("response_body"),
+                    )
                 self.ontology.add_network_connection(
                     NetworkConnection(
                         objectid=object_id,
-                        **v
+                        **network_connection_args
                     ))
 
     def __add_signatures(self) -> None:

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -1,6 +1,6 @@
 import os
 
-from helper import TriageClient, TriageResult
+from helper import DynamicReport, TriageClient, TriageResult
 
 
 # Test TriageResult Class
@@ -41,3 +41,26 @@ def test_TriageResult(requests_mock):
         and i.get("http_details", {}).get("request_method")
         for i in network_connections
     )
+    assert any(
+        i.get("connection_type") == "http"
+        and i.get("http_details", {})
+        .get("response_headers", {})
+        .get("strict-transport-security")
+        == "max-age=604800, max-age=31536000"
+        for i in network_connections
+    )
+
+
+def test_headers_list_to_dict_merges_duplicate_headers():
+    merged = DynamicReport._DynamicReport__headers_list_to_dict(
+        [
+            "strict-transport-security: max-age=604800",
+            "content-type: text/html",
+            "strict-transport-security: max-age=31536000",
+            "malformed header entry",
+        ]
+    )
+
+    assert merged["strict-transport-security"] == "max-age=604800, max-age=31536000"
+    assert merged["content-type"] == "text/html"
+    assert "malformed header entry" not in merged

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -23,4 +23,21 @@ def test_TriageResult(requests_mock):
                       text=behavioral2_data)
     client = TriageClient(token="TESTING")
     sample = client.sample_by_id("240202-3y8f7sefen")
-    TriageResult(client=client, sample=sample)
+    triage_result = TriageResult(client=client, sample=sample)
+
+    network_connections = []
+    for task in triage_result.sample.task_reports:
+        network_connections.extend([i.as_primitives() for i in task.ontology.get_network_connections()])
+
+    assert any(
+        i.get("connection_type") == "dns"
+        and i.get("dns_details", {}).get("domain")
+        and i.get("dns_details", {}).get("lookup_type")
+        for i in network_connections
+    )
+    assert any(
+        i.get("connection_type") == "http"
+        and i.get("http_details", {}).get("request_uri")
+        and i.get("http_details", {}).get("request_method")
+        for i in network_connections
+    )

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -1,5 +1,7 @@
 import os
 
+from assemblyline_service_utilities.common.dynamic_service_helper import OntologyResults
+
 from helper import DynamicReport, TriageClient, TriageResult
 
 
@@ -57,10 +59,145 @@ def test_headers_list_to_dict_merges_duplicate_headers():
             "strict-transport-security: max-age=604800",
             "content-type: text/html",
             "strict-transport-security: max-age=31536000",
+            "Set-Cookie: a=1",
+            "set-cookie: b=2",
             "malformed header entry",
         ]
     )
 
     assert merged["strict-transport-security"] == "max-age=604800, max-age=31536000"
     assert merged["content-type"] == "text/html"
+    assert merged["set-cookie"] == "a=1, b=2"
     assert "malformed header entry" not in merged
+
+
+def _build_dynamic_report(network):
+    return DynamicReport(
+        ontology=OntologyResults(service_name="Triage"),
+        task_id="behavioral-test",
+        version="1.0",
+        sample={"id": "sample-1"},
+        task={},
+        analysis={
+            "submitted": "2024-02-02T23:56:01Z",
+            "reported": "2024-02-02T23:56:45Z",
+            "resource": "host-1",
+        },
+        signatures=[],
+        network=network,
+    )
+
+
+def test_dns_resolved_domains_come_from_answer_values():
+    report = _build_dynamic_report(
+        network={
+            "flows": [
+                {
+                    "id": 10,
+                    "dst": "8.8.8.8:53",
+                    "src": "10.0.0.5:51515",
+                    "proto": "udp",
+                    "first_seen": 1,
+                    "protocols": ["dns"],
+                    "domain": "fallback.example",
+                }
+            ],
+            "requests": [
+                {
+                    "flow": 10,
+                    "index": 1,
+                    "dns_request": {
+                        "domains": ["query.example"],
+                        "questions": [{"name": "query.example", "type": "IN A"}],
+                    },
+                },
+                {
+                    "flow": 10,
+                    "index": 1,
+                    "dns_response": {
+                        "domains": ["query.example"],
+                        "ip": ["203.0.113.10"],
+                        "answers": [
+                            {"name": "query.example", "type": "IN CNAME", "value": "edge.example.net"},
+                            {"name": "edge.example.net", "type": "IN A", "value": "203.0.113.10"},
+                            {"name": "query.example", "type": "IN CNAME", "value": "edge.example.net"},
+                            {"name": "query.example", "type": "IN CNAME", "value": "cdn.example.org"},
+                        ],
+                    },
+                },
+            ],
+        }
+    )
+
+    dns_connections = [
+        connection.as_primitives()
+        for connection in report.ontology.get_network_connections()
+        if connection.as_primitives().get("connection_type") == "dns"
+    ]
+
+    assert len(dns_connections) == 1
+    assert dns_connections[0]["dns_details"]["resolved_domains"] == ["edge.example.net", "cdn.example.org"]
+    assert "query.example" not in dns_connections[0]["dns_details"]["resolved_domains"]
+
+
+def test_dns_repeated_queries_on_same_flow_create_multiple_connections():
+    report = _build_dynamic_report(
+        network={
+            "flows": [
+                {
+                    "id": 20,
+                    "dst": "1.1.1.1:53",
+                    "src": "10.0.0.5:52525",
+                    "proto": "udp",
+                    "first_seen": 1,
+                    "protocols": ["dns"],
+                }
+            ],
+            "requests": [
+                {
+                    "flow": 20,
+                    "index": 1,
+                    "dns_request": {
+                        "domains": ["first.example"],
+                        "questions": [{"name": "first.example", "type": "IN A"}],
+                    },
+                },
+                {
+                    "flow": 20,
+                    "index": 1,
+                    "dns_response": {
+                        "ip": ["198.51.100.10"],
+                        "answers": [{"name": "first.example", "type": "IN A", "value": "198.51.100.10"}],
+                    },
+                },
+                {
+                    "flow": 20,
+                    "index": 2,
+                    "dns_request": {
+                        "domains": ["second.example"],
+                        "questions": [{"name": "second.example", "type": "IN AAAA"}],
+                    },
+                },
+                {
+                    "flow": 20,
+                    "index": 2,
+                    "dns_response": {
+                        "answers": [{"name": "second.example", "type": "IN CNAME", "value": "resolver.example.net"}],
+                    },
+                },
+            ],
+        }
+    )
+
+    dns_connections = [
+        connection.as_primitives()
+        for connection in report.ontology.get_network_connections()
+        if connection.as_primitives().get("connection_type") == "dns"
+    ]
+
+    assert len(dns_connections) == 2
+    assert [connection["dns_details"]["domain"] for connection in dns_connections] == [
+        "first.example",
+        "second.example",
+    ]
+    assert [connection["dns_details"]["lookup_type"] for connection in dns_connections] == ["A", "AAAA"]


### PR DESCRIPTION
Summary
- enrich network flow parsing with HTTP and DNS metadata, normalizing headers/types and storing structured details
- populate ontology network connections with new `NetworkHTTP`/`NetworkDNS` objects based on parsed request/response data
- extend tests to assert expected HTTP and DNS metadata is present on reported connections

Testing
- Not run (not requested)