### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -6,6 +6,9 @@ on:
       - 'v*.stable*'
       - 'v*.dev*'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     uses: ./.github/workflows/python-tests.yml


### PR DESCRIPTION
Potential fix for [https://github.com/scottpas/assemblyline-service-triage-sandbox/security/code-scanning/4](https://github.com/scottpas/assemblyline-service-triage-sandbox/security/code-scanning/4)

Add an explicit `permissions` block at the workflow root in `.github/workflows/build-docker.yml` so all jobs inherit minimal token scope unless overridden.  
Best single fix here is:

- Add:
  - `permissions:`
  - `  contents: read`

Place it after the `on:` trigger block and before `jobs:`. This satisfies CodeQL’s minimum recommendation and preserves existing functionality, since this workflow does not require write access to repository contents through `GITHUB_TOKEN`.

No imports, methods, or dependency changes are needed (YAML workflow-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
