### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -6,10 +6,16 @@ on:
       - 'v*.stable*'
       - 'v*.dev*'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     uses: ./.github/workflows/python-tests.yml
   docker:
+    permissions:
+      contents: read
+      packages: write
     runs-on: ubuntu-24.04
     needs:
       - test


### PR DESCRIPTION
Potential fix for [https://github.com/scottpas/assemblyline-service-triage-sandbox/security/code-scanning/3](https://github.com/scottpas/assemblyline-service-triage-sandbox/security/code-scanning/3)

Add an explicit `permissions` block in `.github/workflows/build-docker.yml` so the workflow does not rely on ambient defaults.

Best single fix without changing functionality:
- Define workflow-level minimal read permissions:
  - `contents: read` (needed for checkout/read repo content).
- Override the `docker` job with the additional write scope it actually needs:
  - `packages: write` (required to push container images when using `GITHUB_TOKEN`; keeping least privilege localized to that job).
  
This keeps the `test` reusable-workflow job restricted to read-only defaults from this file while giving only the publish job elevated rights.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
