### PR TITLE
feat: enrich MalwareConfig ODM, surface signature descriptions, recover overview data, tag ATT&CK per signature

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ indent-style = "space"
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 addopts = "-ra"
-pythonpath = ["src"]
+pythonpath = ["src", "tests"]
 
 [tool.coverage.run]
 source = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ exclude_dirs = ["tests"]
 [tool.ty.environment]
 python-version = "3.12"
 python-platform = "linux"
-root = ["./src"]
+root = ["./src", "./tests"]
 
 [tool.ty.src]
 include = ["src", "tests"]

--- a/src/triage_sandbox/models.py
+++ b/src/triage_sandbox/models.py
@@ -4,11 +4,14 @@ from typing import Any, List, Optional
 
 import regex
 from assemblyline.odm.models.ontology.results.malware_config import (
+    DNS,
     FTP,
     HTTP,
     Cryptocurrency,
+    Encryption,
     GeneralConnection,
     MalwareConfig,
+    Path,
 )
 
 from .constants import EXTRA_CONFIG_FIELDS, SERVICE_NAME
@@ -146,6 +149,54 @@ class Config:
             ]
             if not self.family:
                 data["family"] = ["UNKNOWN"]
+        # Map config.keys[] → MalwareConfig.encryption[]
+        encryptions: list[Encryption] = []
+        for key_entry in self.keys or []:
+            kind = key_entry.get("kind", "") or ""
+            raw_value = key_entry.get("value")
+            if raw_value is None:
+                continue
+            encryptions.append(
+                Encryption(
+                    data={
+                        "algorithm": kind.split(".")[0] if kind else None,
+                        "key": str(raw_value),
+                        "usage": "config",
+                    }
+                )
+            )
+        # Map config.dns[] → MalwareConfig.dns[]
+        dns_entries: list[DNS] = []
+        for dns_str in self.dns or []:
+            try:
+                ip_address(dns_str)
+                dns_entries.append(DNS(data={"ip": dns_str, "usage": "c2"}))
+            except ValueError:
+                dns_entries.append(DNS(data={"hostname": dns_str, "usage": "c2"}))
+        # Map config.attr → paths[], sleep_delay, encryption[] (additive; attr stays in other for full context)
+        attr = self.attr or {}
+        paths: list[Path] = []
+        _INSTALL_PATH_KEYS = ("install_folder", "install_file", "install_name", "subdirectory")
+        for path_key in _INSTALL_PATH_KEYS:
+            if attr.get(path_key):
+                paths.append(Path(data={"path": str(attr[path_key]), "usage": "install"}))
+        if attr.get("log_directory"):
+            paths.append(Path(data={"path": str(attr["log_directory"]), "usage": "logs"}))
+        for delay_key in ("delay", "reconnect_delay", "sleep_delay"):
+            if isinstance(attr.get(delay_key), int):
+                data["sleep_delay"] = attr[delay_key]
+                break
+        if attr.get("encryption_key"):
+            enc_data: dict[str, Any] = {"key": str(attr["encryption_key"]), "usage": "config"}
+            if attr.get("key_salt"):
+                enc_data["salt"] = str(attr["key_salt"])
+            encryptions.append(Encryption(data=enc_data))
+        if encryptions:
+            data["encryption"] = encryptions
+        if dns_entries:
+            data["dns"] = dns_entries
+        if paths:
+            data["paths"] = paths
         other: dict[str, Any] = {}
         for field in EXTRA_CONFIG_FIELDS:
             value = getattr(self, field)

--- a/src/triage_sandbox/models.py
+++ b/src/triage_sandbox/models.py
@@ -174,7 +174,7 @@ class Config:
             except ValueError:
                 dns_entries.append(DNS(data={"hostname": dns_str, "usage": "c2"}))
         # Map config.attr → paths[], sleep_delay, encryption[] (additive; attr stays in other for full context)
-        attr = self.attr or {}
+        attr = self.attr if isinstance(self.attr, dict) else {}
         paths: list[Path] = []
         _INSTALL_PATH_KEYS = ("install_folder", "install_file", "install_name", "subdirectory")
         for path_key in _INSTALL_PATH_KEYS:

--- a/src/triage_sandbox/report.py
+++ b/src/triage_sandbox/report.py
@@ -1,4 +1,5 @@
 import itertools
+import json
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from ipaddress import ip_address
@@ -443,13 +444,13 @@ class TriageResult:
         self.sample.get_task_reports(client)
         self.malware_config = list(itertools.chain.from_iterable(r.malware_config for r in self.sample.task_reports))
 
-        # Configs already recovered from behavioral reports (dedup key: family + sorted c2 list)
-        behavioral_config_keys: set[tuple] = set()
+        # Configs already recovered from behavioral reports (dedup key: canonical JSON of filtered config)
+        behavioral_config_keys: set[str] = set()
         for report in self.sample.task_reports:
             for item in report.extracted or []:
                 cfg = item.get("config") or {}
                 if cfg.get("family"):
-                    key = (cfg["family"].lower(), tuple(sorted(cfg.get("c2") or [])))
+                    key = json.dumps(_filter_config(cfg), sort_keys=True)
                     behavioral_config_keys.add(key)
 
         # Collect seen signature names across all behavioral tasks (for overview dedup)
@@ -474,10 +475,10 @@ class TriageResult:
                 family = cfg.get("family", "")
                 if not family:
                     continue
-                key = (family.lower(), tuple(sorted(cfg.get("c2") or [])))
+                filtered = _filter_config(cfg)
+                key = json.dumps(filtered, sort_keys=True)
                 if key in behavioral_config_keys:
                     continue  # already extracted from a behavioral report
-                filtered = _filter_config(cfg)
                 try:
                     mc = Config(**filtered).create_MalwareConfig()
                     self.malware_config.append(mc)

--- a/src/triage_sandbox/report.py
+++ b/src/triage_sandbox/report.py
@@ -278,6 +278,9 @@ class DynamicReport:
                     classification=DEFAULT_SIGNATURE_CLASSIFICATION,
                 )
                 self.ontology.add_signature(al_sig)
+            # Capture human-readable description for display in result sections
+            if sig.get("desc"):
+                self.signature_descriptions[name] = sig["desc"]
             for indicator in sig.get("indicators", []):
                 if indicator.get("procid") and indicator["procid"] in self._id_pid_map:
                     try:
@@ -338,6 +341,8 @@ class DynamicReport:
         self.network_tags: List[tuple] = []  # type: ignore[type-arg]
         self.malware_config: List[MalwareConfig] = []
         self._id_pid_map: dict[int, int] = {}
+        # Maps normalized signature name → human-readable description (sig.desc)
+        self.signature_descriptions: dict[str, str] = {}
         self.__add_sandbox()
         if self.processes:
             self.__add_processes()
@@ -398,8 +403,91 @@ class Sample:
                 )
 
 
+# Keys accepted by the Config dataclass; guards against unknown future Triage config fields
+_CONFIG_DATACLASS_FIELDS = frozenset(
+    {
+        "family",
+        "tags",
+        "rule",
+        "c2",
+        "version",
+        "botnet",
+        "campaign",
+        "mutex",
+        "decoy",
+        "wallet",
+        "dns",
+        "keys",
+        "webinject",
+        "command_lines",
+        "listen_addr",
+        "listen_port",
+        "listen_for",
+        "shellcode",
+        "extracted_pe",
+        "credentials",
+        "attr",
+        "raw",
+    }
+)
+
+
+def _filter_config(cfg: dict) -> dict:  # type: ignore[type-arg]
+    """Return only keys accepted by the Config dataclass; drops unknown future Triage fields."""
+    return {k: v for k, v in cfg.items() if k in _CONFIG_DATACLASS_FIELDS}
+
+
 class TriageResult:
     def __init__(self, client: TriageClient, sample: dict) -> None:  # type: ignore[type-arg]
         self.sample = Sample(**sample)
         self.sample.get_task_reports(client)
         self.malware_config = list(itertools.chain.from_iterable(r.malware_config for r in self.sample.task_reports))
+
+        # Configs already recovered from behavioral reports (dedup key: family + sorted c2 list)
+        behavioral_config_keys: set[tuple] = set()
+        for report in self.sample.task_reports:
+            for item in report.extracted or []:
+                cfg = item.get("config") or {}
+                if cfg.get("family"):
+                    key = (cfg["family"].lower(), tuple(sorted(cfg.get("c2") or [])))
+                    behavioral_config_keys.add(key)
+
+        # Collect seen signature names across all behavioral tasks (for overview dedup)
+        behavioral_sig_names: set[str] = set()
+        for report in self.sample.task_reports:
+            for sig in report.signatures or []:
+                name = sig.get("label") or sig.get("name", "")
+                if name:
+                    behavioral_sig_names.add(name)
+
+        self.overview_configs: list[dict] = []  # type: ignore[type-arg]
+        self.overview_signatures: list[dict] = []  # type: ignore[type-arg]
+
+        try:
+            overview = client.overview_report(self.sample.id)
+        except Exception:
+            overview = {}
+
+        if overview:
+            for item in overview.get("extracted") or []:
+                cfg = item.get("config") or {}
+                family = cfg.get("family", "")
+                if not family:
+                    continue
+                key = (family.lower(), tuple(sorted(cfg.get("c2") or [])))
+                if key in behavioral_config_keys:
+                    continue  # already extracted from a behavioral report
+                filtered = _filter_config(cfg)
+                try:
+                    mc = Config(**filtered).create_MalwareConfig()
+                    self.malware_config.append(mc)
+                    self.overview_configs.append(cfg)
+                    behavioral_config_keys.add(key)  # prevent double-adding if overview has dupes
+                except Exception:
+                    pass
+
+            for sig in overview.get("signatures") or []:
+                name = sig.get("label") or sig.get("name", "")
+                if name and name not in behavioral_sig_names:
+                    self.overview_signatures.append(sig)
+                    behavioral_sig_names.add(name)

--- a/src/triage_sandbox/service.py
+++ b/src/triage_sandbox/service.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 from typing import Any, cast
 
+from assemblyline.common.attack_map import attack_map
 from assemblyline.odm.models.ontology.results import NetworkConnection as NetworkConnectionModel
 from assemblyline.odm.models.ontology.results import Process as ProcessModel
 from assemblyline.odm.models.ontology.results import Sandbox as SandboxModel
@@ -139,6 +140,57 @@ class TriageSandbox(ServiceBase):
             sandbox_section.add_line(f"URL: {self.web_url}/{triage_result.sample.id}")
             sandbox_section.add_line(f"Submitted: {triage_result.sample.submitted}")
             sandbox_section.add_line(f"Completed: {triage_result.sample.completed}")
+            # Single Overview section: signatures + malware config from overview report
+            if triage_result.overview_signatures or triage_result.overview_configs:
+                overview_section = ResultSection(title_text="Overview", auto_collapse=True)
+                if triage_result.overview_signatures:
+                    overview_sigs = ResultSection(title_text="Signatures", auto_collapse=True)
+                    for sig in triage_result.overview_signatures:
+                        raw_name = sig.get("label") or sig.get("name", "")
+                        name = raw_name.upper()
+                        s = ResultSection(title_text=name)
+                        s.add_tag(tag_type="dynamic.signature.name", value=name)
+                        families = [t.split(":")[-1].upper() for t in sig.get("tags", []) if t.startswith("family:")]
+                        for f in families:
+                            s.add_tag(tag_type="attribution.family", value=f)
+                        score = (sig.get("score") or 0) * 100
+                        if score >= 1000:
+                            s.set_heuristic(5, signature=name)
+                        elif score >= 800:
+                            s.set_heuristic(4, signature=name)
+                        elif score >= 500:
+                            s.set_heuristic(3, signature=name)
+                        elif score >= 100:
+                            s.set_heuristic(2, signature=name)
+                        else:
+                            s.set_heuristic(1, signature=name)
+                        for ttp_id in sig.get("ttp", []):
+                            if attack_map.get(ttp_id):
+                                s.heuristic.add_attack_id(ttp_id)
+                        if sig.get("desc"):
+                            s.add_line(sig["desc"])
+                        overview_sigs.add_subsection(s)
+                    overview_section.add_subsection(overview_sigs)
+                if triage_result.overview_configs:
+                    overview_mc = ResultSection(title_text="Malware Config", auto_collapse=True)
+                    for cfg in triage_result.overview_configs:
+                        family_upper = cfg.get("family", "UNKNOWN").upper()
+                        m = ResultTableSection(title_text=family_upper)
+                        extract_iocs_from_text_blob(blob=json.dumps(cfg), result_section=m)
+                        m.set_heuristic(100, signature=family_upper)
+                        m.add_tag(tag_type="attribution.family", value=family_upper)
+                        m.add_subsection(
+                            ResultSection(
+                                title_text="Raw Config",
+                                body_format="JSON",
+                                body=json.dumps(cfg),
+                                auto_collapse=True,
+                            )
+                        )
+                        overview_mc.add_subsection(m)
+                    overview_section.add_subsection(overview_mc)
+                sandbox_section.add_subsection(overview_section)
+
             for task in triage_result.sample.task_reports:
                 _attach_dynamic_ontology(self, task.ontology)
                 task_section = ResultSection(f"Task: {task.task_id}")
@@ -154,6 +206,8 @@ class TriageSandbox(ServiceBase):
                         for attr in sig.attributes:
                             if attr.source.ontology_id.startswith("process_"):
                                 sig_subsections[name].add_tag(tag_type="dynamic.processtree_id", value=attr.source.tag)
+                        for attack in sig.attacks:
+                            sig_subsections[name].heuristic.add_attack_id(attack["attack_id"])
                     else:
                         s = ResultSection(title_text=name)
                         s.add_tag(tag_type="dynamic.signature.name", value=name)
@@ -170,9 +224,15 @@ class TriageSandbox(ServiceBase):
                             s.set_heuristic(2, signature=name)
                         else:
                             s.set_heuristic(1, signature=name)
+                        for attack in sig.attacks:
+                            s.heuristic.add_attack_id(attack["attack_id"])
                         for attr in sig.attributes:
                             if attr.source.ontology_id.startswith("process_"):
                                 s.add_tag(tag_type="dynamic.processtree_id", value=attr.source.tag)
+                        # Surface the human-readable description when present
+                        desc = task.signature_descriptions.get(sig.name)
+                        if desc:
+                            s.add_line(desc)
                         sig_subsections[name] = s
                 for sig_section in reversed(sorted(sig_subsections.values(), key=lambda s: s.heuristic.heur_id)):
                     sigs_section.add_subsection(sig_section)
@@ -183,13 +243,6 @@ class TriageSandbox(ServiceBase):
                 for tag_type, value in task.network_tags:
                     ioc_section.add_tag(tag_type=tag_type, value=value)
                 task_section.add_subsection(ioc_section)
-                if task.analysis.get("ttp"):
-                    ttp_section = ResultSection("ATT&CK Techniques", auto_collapse=True)
-                    for t in task.analysis["ttp"]:
-                        ttp_sub = ResultSection(title_text=t)
-                        ttp_sub.set_heuristic(10, attack_id=t)
-                        ttp_section.add_subsection(ttp_sub)
-                    task_section.add_subsection(ttp_section)
                 if task.extracted:
                     malware_section = ResultSection(title_text="Malware Config", auto_collapse=True)
                     for e in task.extracted:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -294,6 +294,11 @@ def triage_client(requests_mock, sample_text, behavioral1_text, behavioral2_text
         text=behavioral2_text,
     )
     requests_mock.get(search_url, text=search_body)
+    # Overview endpoint — return empty by default so existing TriageResult tests are unaffected
+    requests_mock.get(
+        f"https://api.tria.ge/v1/samples/{SAMPLE_ID}/overview.json",
+        text=json.dumps({}),
+    )
 
     return TriageClient(token="TESTING")
 
@@ -397,5 +402,9 @@ def mock_triage_api(requests_mock, sample_text, behavioral1_text, behavioral2_te
     requests_mock.get(
         f"https://api.tria.ge/v0/search?query={encoded}&limit=1",
         text=json.dumps({"data": [{"id": SAMPLE_ID}], "next": None}),
+    )
+    requests_mock.get(
+        f"https://api.tria.ge/v1/samples/{SAMPLE_ID}/overview.json",
+        text=json.dumps({}),
     )
     return requests_mock

--- a/tests/test_dynamic_report.py
+++ b/tests/test_dynamic_report.py
@@ -425,3 +425,40 @@ def test_dns_request_without_response_does_not_raise():
 def test_empty_network_initializes_empty_network_tags():
     dr = make_report(network={})
     assert dr.network_tags == []
+
+
+# ---------------------------------------------------------------------------
+# 8. Signature descriptions
+# ---------------------------------------------------------------------------
+
+
+def test_signature_descriptions_populated_from_desc_field():
+    """signatures[].desc must be captured in signature_descriptions keyed by name."""
+    dr = make_report(
+        signatures=[
+            {
+                "label": "darksiderat",
+                "score": 10,
+                "desc": "DarkSideRAT is a remote access trojan.",
+                "tags": ["family:darksiderat"],
+            },
+            {
+                "label": "interesting_sig",
+                "score": 5,
+                # No desc — must not appear in signature_descriptions
+            },
+        ]
+    )
+    assert "darksiderat" in dr.signature_descriptions
+    assert dr.signature_descriptions["darksiderat"] == "DarkSideRAT is a remote access trojan."
+    assert "interesting_sig" not in dr.signature_descriptions
+
+
+def test_signature_descriptions_empty_when_no_desc():
+    """When no signatures have desc, signature_descriptions must be empty."""
+    dr = make_report(
+        signatures=[
+            {"label": "sig_without_desc", "score": 3},
+        ]
+    )
+    assert dr.signature_descriptions == {}

--- a/tests/test_malware_config.py
+++ b/tests/test_malware_config.py
@@ -142,6 +142,131 @@ def test_config_extra_fields_go_to_other():
     assert other["decoy"] == ["d"]
 
 
+def test_config_keys_go_to_encryption():
+    """config.keys[] must be mapped to MalwareConfig.encryption[]."""
+    mc = Config(
+        family="asyncrat",
+        keys=[{"kind": "aes.plain", "key": "aes_key", "value": "gtrdpQ8JK9HBOus1FEuCgQVvSBL7sa5y"}],
+    ).create_MalwareConfig()
+    prim = mc.as_primitives(strip_null=True)
+    enc_entries = prim.get("encryption", [])
+    assert len(enc_entries) == 1
+    assert enc_entries[0]["algorithm"] == "aes"
+    assert enc_entries[0]["key"] == "gtrdpQ8JK9HBOus1FEuCgQVvSBL7sa5y"
+    assert enc_entries[0]["usage"] == "config"
+
+
+def test_config_keys_with_none_value_skipped():
+    """keys[] entries with null value must not produce an encryption entry."""
+    mc = Config(
+        family="x",
+        keys=[{"kind": "rsa", "key": "rsa_key", "value": None}],
+    ).create_MalwareConfig()
+    prim = mc.as_primitives(strip_null=True)
+    assert "encryption" not in prim
+
+
+def test_config_multiple_keys():
+    """Multiple keys[] entries produce multiple encryption entries."""
+    mc = Config(
+        family="x",
+        keys=[
+            {"kind": "aes.plain", "key": "k1", "value": "AAAAAA"},
+            {"kind": "chacha20", "key": "k2", "value": "BBBBBB"},
+        ],
+    ).create_MalwareConfig()
+    prim = mc.as_primitives(strip_null=True)
+    enc_entries = prim.get("encryption", [])
+    assert len(enc_entries) == 2
+    algos = {e["algorithm"] for e in enc_entries}
+    assert algos == {"aes", "chacha20"}
+
+
+def test_config_dns_ip_goes_to_dns():
+    """config.dns[] with an IP string must produce a dns[] entry with ip field."""
+    mc = Config(family="x", dns=["8.8.8.8", "1.1.1.1"]).create_MalwareConfig()
+    prim = mc.as_primitives(strip_null=True)
+    dns_entries = prim.get("dns", [])
+    assert len(dns_entries) == 2
+    ips = {e["ip"] for e in dns_entries}
+    assert ips == {"8.8.8.8", "1.1.1.1"}
+    assert all(e.get("usage") == "c2" for e in dns_entries)
+
+
+def test_config_dns_hostname_goes_to_dns():
+    """config.dns[] with a hostname string must produce a dns[] entry with hostname field."""
+    mc = Config(family="x", dns=["resolver.example.com"]).create_MalwareConfig()
+    prim = mc.as_primitives(strip_null=True)
+    dns_entries = prim.get("dns", [])
+    assert len(dns_entries) == 1
+    assert dns_entries[0]["hostname"] == "resolver.example.com"
+    assert "ip" not in dns_entries[0]
+
+
+def test_config_attr_install_folder_goes_to_paths():
+    """config.attr install_folder must produce a paths[] entry with usage 'install'."""
+    mc = Config(
+        family="asyncrat", attr={"install": False, "install_folder": "%AppData%", "delay": 3}
+    ).create_MalwareConfig()
+    prim = mc.as_primitives(strip_null=True)
+    paths = prim.get("paths", [])
+    install_paths = [p for p in paths if p.get("usage") == "install"]
+    assert len(install_paths) >= 1
+    assert any(p["path"] == "%AppData%" for p in install_paths)
+
+
+def test_config_attr_delay_goes_to_sleep_delay():
+    """config.attr delay (int) must be mapped to sleep_delay."""
+    mc = Config(family="asyncrat", attr={"delay": 3}).create_MalwareConfig()
+    prim = mc.as_primitives(strip_null=True)
+    assert prim.get("sleep_delay") == 3
+
+
+def test_config_attr_reconnect_delay_goes_to_sleep_delay():
+    """config.attr reconnect_delay falls back if delay is absent."""
+    mc = Config(family="quasar", attr={"reconnect_delay": 5000}).create_MalwareConfig()
+    prim = mc.as_primitives(strip_null=True)
+    assert prim.get("sleep_delay") == 5000
+
+
+def test_config_attr_encryption_key_goes_to_encryption():
+    """config.attr encryption_key must produce an encryption entry."""
+    mc = Config(
+        family="quasar",
+        attr={
+            "encryption_key": "B9190F8255DE3C0B619CB5B7719B9B61206842F7",
+            "key_salt": "bfeb1e56fbcd973bb219022430a57843003d5644d21e62b9d4f180e7e6c33941",
+        },
+    ).create_MalwareConfig()
+    prim = mc.as_primitives(strip_null=True)
+    enc_entries = prim.get("encryption", [])
+    attr_enc = [e for e in enc_entries if e.get("key") == "B9190F8255DE3C0B619CB5B7719B9B61206842F7"]
+    assert len(attr_enc) == 1
+    assert attr_enc[0]["salt"] == "bfeb1e56fbcd973bb219022430a57843003d5644d21e62b9d4f180e7e6c33941"
+    assert attr_enc[0]["usage"] == "config"
+
+
+def test_config_attr_log_directory_goes_to_paths():
+    """config.attr log_directory must produce a paths[] entry with usage 'logs'."""
+    mc = Config(family="quasar", attr={"log_directory": "Logs"}).create_MalwareConfig()
+    prim = mc.as_primitives(strip_null=True)
+    paths = prim.get("paths", [])
+    log_paths = [p for p in paths if p.get("usage") == "logs"]
+    assert len(log_paths) == 1
+    assert log_paths[0]["path"] == "Logs"
+
+
+def test_config_attr_still_in_other():
+    """config.attr must still appear in other{} for full lossless context."""
+    mc = Config(
+        family="asyncrat", attr={"install": False, "install_folder": "%AppData%", "delay": 3}
+    ).create_MalwareConfig()
+    prim = mc.as_primitives(strip_null=True)
+    other = prim.get("other", {})
+    assert "attr" in other
+    assert other["attr"]["install_folder"] == "%AppData%"
+
+
 def test_ransom_with_target_field_does_not_raise():
     mc = Ransom(note="pay up", family="x", target="files").create_MalwareConfig()
     prim = mc.as_primitives(strip_null=True)

--- a/tests/test_sample_and_result.py
+++ b/tests/test_sample_and_result.py
@@ -6,8 +6,11 @@ tria.ge API endpoints on requests_mock and returns a TriageClient.
 """
 
 import copy
+import json
 
 from triage_sandbox.report import DynamicReport, Sample, TriageResult
+
+OVERVIEW_URL = "https://api.tria.ge/v1/samples/{id}/overview.json"
 
 SAMPLE_ID = "240202-3y8f7sefen"
 
@@ -115,9 +118,227 @@ def test_triageresult(triage_client):
 def test_triageresult_malware_config_chaining(triage_client):
     """
     TriageResult.malware_config must equal the union of per-task malware_config
-    lists, confirming itertools.chain(*...) wiring.
+    lists when the overview returns no additional configs.
     """
     tr = TriageResult(triage_client, triage_client.sample_by_id(SAMPLE_ID))
 
     expected_total = sum(len(r.malware_config) for r in tr.sample.task_reports)
     assert len(tr.malware_config) == expected_total
+
+
+# ---------------------------------------------------------------------------
+# TriageResult overview recovery tests
+# ---------------------------------------------------------------------------
+
+
+def _make_quasar_overview(sample_id: str) -> dict:
+    """Overview shaped like the real quasar sample: config absent from behavioral reports."""
+    return {
+        "analysis": {"family": ["quasar"], "score": 10, "tags": ["family:quasar"]},
+        "extracted": [
+            {
+                "config": {
+                    "family": "quasar",
+                    "rule": "Quasar",
+                    "c2": ["5.75.188.31:4782", "95.179.201.247:4782"],
+                    "botnet": "Admin@Quasar",
+                    "mutex": ["QSR_MUTEX_1ab34ef"],
+                    "attr": {
+                        "encryption_key": "B9190F8255DE3C0B619CB5B7719B9B61206842F7",
+                        "key_salt": "bfeb1e56fbcd973bb219022430a57843003d5644d21e62b9d4f180e7e6c33941",
+                        "install_name": "vcredist.exe",
+                        "reconnect_delay": 5000,
+                    },
+                },
+                "resource": "sample",
+                "tasks": ["behavioral1"],
+            }
+        ],
+        "signatures": [
+            {
+                "label": "quasar",
+                "name": "Family: Quasar",
+                "score": 10,
+                "desc": "Quasar is a remote administration tool.",
+                "tags": ["family:quasar"],
+            }
+        ],
+    }
+
+
+def test_overview_config_recovered_when_behavioral_has_none(requests_mock, sample_json):
+    """
+    When behavioral reports have no extracted config, TriageResult must recover
+    the config from the overview report.
+    Simulates the quasar scenario: behavioral tasks have empty extracted blocks.
+    """
+    from triage import Client as TriageClient
+
+    # Build sample + behavioral reports with NO extracted block
+    sample_no_config = copy.deepcopy(sample_json)
+    b1 = _behavioral_report_no_config("behavioral1")
+    b2 = _behavioral_report_no_config("behavioral2")
+    overview = _make_quasar_overview(SAMPLE_ID)
+
+    requests_mock.get(f"https://api.tria.ge/v0/samples/{SAMPLE_ID}", text=json.dumps(sample_no_config))
+    requests_mock.get(f"https://api.tria.ge/v0/samples/{SAMPLE_ID}/behavioral1/report_triage.json", text=json.dumps(b1))
+    requests_mock.get(f"https://api.tria.ge/v0/samples/{SAMPLE_ID}/behavioral2/report_triage.json", text=json.dumps(b2))
+    requests_mock.get(f"https://api.tria.ge/v1/samples/{SAMPLE_ID}/overview.json", text=json.dumps(overview))
+
+    client = TriageClient(token="TESTING")
+    tr = TriageResult(client, client.sample_by_id(SAMPLE_ID))
+
+    assert len(tr.overview_configs) == 1
+    assert tr.overview_configs[0]["family"] == "quasar"
+    # The config must land in malware_config (behavioral contributed 0)
+    families = [mc.as_primitives(strip_null=True).get("family", []) for mc in tr.malware_config]
+    assert any("QUASAR" in f for f in families)
+
+
+def test_overview_config_skipped_when_already_in_behavioral(requests_mock, sample_json):
+    """
+    When a config from the overview has the same family+c2 as one already
+    extracted from behavioral reports, it must NOT be added again (no double-scoring).
+    """
+    from triage import Client as TriageClient
+
+    # Build overview with same family+c2 as what build_report() puts in behavioral
+    b1_family = "fabookie"
+    b1_c2 = f"http://{b1_family}.example/gate/"
+    overview = {
+        "extracted": [
+            {
+                "config": {
+                    "family": b1_family,
+                    "c2": [b1_c2],
+                    "rule": b1_family.capitalize(),
+                },
+                "tasks": ["behavioral1"],
+            }
+        ],
+        "signatures": [],
+    }
+    from conftest import build_report
+
+    b1 = build_report("behavioral1", family=b1_family)
+    b2 = build_report("behavioral2", family="vidar")
+    requests_mock.get(f"https://api.tria.ge/v0/samples/{SAMPLE_ID}", text=json.dumps(sample_json))
+    requests_mock.get(f"https://api.tria.ge/v0/samples/{SAMPLE_ID}/behavioral1/report_triage.json", text=json.dumps(b1))
+    requests_mock.get(f"https://api.tria.ge/v0/samples/{SAMPLE_ID}/behavioral2/report_triage.json", text=json.dumps(b2))
+    requests_mock.get(f"https://api.tria.ge/v1/samples/{SAMPLE_ID}/overview.json", text=json.dumps(overview))
+
+    client = TriageClient(token="TESTING")
+    tr = TriageResult(client, client.sample_by_id(SAMPLE_ID))
+
+    # No overview configs should be added (behavioral1 already has fabookie with same c2)
+    assert tr.overview_configs == []
+    # Total malware_config count must equal only what behavioral reports produced (2 tasks)
+    behavioral_total = sum(len(r.malware_config) for r in tr.sample.task_reports)
+    assert len(tr.malware_config) == behavioral_total
+
+
+def test_overview_signatures_recovered_when_absent_from_behavioral(requests_mock, sample_json):
+    """Overview-only signatures must be captured in overview_signatures."""
+    from triage import Client as TriageClient
+
+    b1 = _behavioral_report_no_config("behavioral1")
+    b2 = _behavioral_report_no_config("behavioral2")
+    overview = _make_quasar_overview(SAMPLE_ID)
+
+    requests_mock.get(f"https://api.tria.ge/v0/samples/{SAMPLE_ID}", text=json.dumps(sample_json))
+    requests_mock.get(f"https://api.tria.ge/v0/samples/{SAMPLE_ID}/behavioral1/report_triage.json", text=json.dumps(b1))
+    requests_mock.get(f"https://api.tria.ge/v0/samples/{SAMPLE_ID}/behavioral2/report_triage.json", text=json.dumps(b2))
+    requests_mock.get(f"https://api.tria.ge/v1/samples/{SAMPLE_ID}/overview.json", text=json.dumps(overview))
+
+    client = TriageClient(token="TESTING")
+    tr = TriageResult(client, client.sample_by_id(SAMPLE_ID))
+
+    assert len(tr.overview_signatures) == 1
+    assert tr.overview_signatures[0]["label"] == "quasar"
+    assert tr.overview_signatures[0].get("desc") == "Quasar is a remote administration tool."
+
+
+def test_overview_error_is_non_fatal(requests_mock, sample_json):
+    """A 404 or error from overview_report must not crash TriageResult."""
+    from conftest import build_report
+    from triage import Client as TriageClient
+
+    b1 = build_report("behavioral1")
+    b2 = build_report("behavioral2", family="vidar")
+    requests_mock.get(f"https://api.tria.ge/v0/samples/{SAMPLE_ID}", text=json.dumps(sample_json))
+    requests_mock.get(f"https://api.tria.ge/v0/samples/{SAMPLE_ID}/behavioral1/report_triage.json", text=json.dumps(b1))
+    requests_mock.get(f"https://api.tria.ge/v0/samples/{SAMPLE_ID}/behavioral2/report_triage.json", text=json.dumps(b2))
+    requests_mock.get(f"https://api.tria.ge/v1/samples/{SAMPLE_ID}/overview.json", status_code=404)
+
+    client = TriageClient(token="TESTING")
+    tr = TriageResult(client, client.sample_by_id(SAMPLE_ID))
+
+    # Must not raise; behavioral configs still collected
+    assert len(tr.sample.task_reports) == 2
+    assert tr.overview_configs == []
+
+
+# ---------------------------------------------------------------------------
+# Helpers for overview tests
+# ---------------------------------------------------------------------------
+
+
+def _behavioral_report_no_config(task_id: str) -> dict:
+    """Behavioral report with empty signatures and no extracted config (like quasar)."""
+    pid = 2104 if task_id == "behavioral1" else 3104
+    return {
+        "version": "0.3.0",
+        "sample": {
+            "id": SAMPLE_ID,
+            "score": 10,
+            "target": "sample.exe",
+            "size": 2048,
+            "md5": "0" * 32,
+            "sha1": "0" * 40,
+            "sha256": "0" * 64,
+            "sha512": "0" * 128,
+            "ssdeep": "48:abc",
+            "static_tags": [],
+            "submitted": "2024-02-02T23:56:27Z",
+        },
+        "task": {
+            "target": "sample.exe",
+            "size": 2048,
+            "md5": "0" * 32,
+            "sha1": "0" * 40,
+            "sha256": "0" * 64,
+            "sha512": "0" * 128,
+            "ssdeep": "48:abc",
+            "static_tags": [],
+        },
+        "analysis": {
+            "score": 10,
+            "submitted": "2024-02-02T23:56:27Z",
+            "reported": "2024-02-02T23:59:09Z",
+            "resource": "win7-20231215-en",
+            "platform": "windows7_x64",
+            "tags": [],
+            "resource_tags": [],
+            "features": [],
+            "backend": "host",
+            "max_time_kernel": 180,
+            "max_time_network": 180,
+        },
+        "processes": [
+            {
+                "procid": 1,
+                "procid_parent": 0,
+                "pid": pid,
+                "ppid": 1220,
+                "image": "C:\\Windows\\vcredist.exe",
+                "cmd": '"C:\\Windows\\vcredist.exe"',
+                "orig": True,
+                "started": 154,
+            }
+        ],
+        "signatures": [],
+        "network": {"flows": [], "requests": []},
+        "extracted": [],
+        "dumped": [],
+        "tags": [],
+    }

--- a/tests/test_sample_and_result.py
+++ b/tests/test_sample_and_result.py
@@ -197,7 +197,7 @@ def test_overview_config_recovered_when_behavioral_has_none(requests_mock, sampl
 
 def test_overview_config_skipped_when_already_in_behavioral(requests_mock, sample_json):
     """
-    When a config from the overview has the same family+c2 as one already
+    When a config from the overview is identical (same filtered content) to one already
     extracted from behavioral reports, it must NOT be added again (no double-scoring).
     """
     from triage import Client as TriageClient
@@ -230,7 +230,7 @@ def test_overview_config_skipped_when_already_in_behavioral(requests_mock, sampl
     client = TriageClient(token="TESTING")
     tr = TriageResult(client, client.sample_by_id(SAMPLE_ID))
 
-    # No overview configs should be added (behavioral1 already has fabookie with same c2)
+    # No overview configs should be added (identical to behavioral1's fabookie config)
     assert tr.overview_configs == []
     # Total malware_config count must equal only what behavioral reports produced (2 tasks)
     behavioral_total = sum(len(r.malware_config) for r in tr.sample.task_reports)

--- a/tests/test_service_integration.py
+++ b/tests/test_service_integration.py
@@ -197,16 +197,37 @@ def test_execute_malware_config_section(triage_service, make_request, mock_triag
         assert family_table.heuristic.heur_id == 100
 
 
-def test_execute_attack_techniques_section_attached(triage_service, make_request, mock_triage_api):
-    """Each task section should contain an ATT&CK Techniques subsection (analysis.ttp is present)."""
+def test_execute_attack_ids_on_signature_heuristics(triage_service, make_request, mock_triage_api):
+    """
+    ATT&CK techniques from signatures with TTPs must be attached to their signature
+    subsection heuristics, NOT in a standalone 'ATT&CK Techniques' section.
+
+    The fixture family signature carries ttp:['T1082'] (conftest.py:140-146).
+    After execution: at least one signature subsection in each task must have T1082
+    in its heuristic attack_ids, and no standalone 'ATT&CK Techniques' section may exist.
+    """
     svc = triage_service
     req = make_request()
     svc.execute(req)
 
     sandbox_section = req.result.sections[0]
     for task_section in sandbox_section.subsections:
-        ttp = find_subsection(task_section, "ATT&CK Techniques")
-        assert ttp is not None, f"ATT&CK Techniques subsection missing from {task_section.title_text}"
+        # Standalone section must be gone
+        ttp_standalone = find_subsection(task_section, "ATT&CK Techniques")
+        assert ttp_standalone is None, (
+            f"Standalone 'ATT&CK Techniques' section must not exist in {task_section.title_text}"
+        )
+
+        # At least one signature subsection must carry T1082 on its heuristic
+        sigs = find_subsection(task_section, "Signatures")
+        assert sigs is not None, f"No Signatures subsection in {task_section.title_text}"
+        attack_ids_found = set()
+        for sig_sub in sigs.subsections:
+            if sig_sub.heuristic and sig_sub.heuristic.attack_ids:
+                attack_ids_found.update(sig_sub.heuristic.attack_ids)
+        assert "T1082" in attack_ids_found, (
+            f"Expected T1082 in signature heuristic attack_ids for {task_section.title_text}; got {attack_ids_found}"
+        )
 
 
 def test_execute_pcap_extraction(triage_service, make_request, mock_triage_api):


### PR DESCRIPTION
## Summary

- Map `config.keys[]` to `MalwareConfig.encryption[]`, `config.dns[]` to `MalwareConfig.dns[]`, and `config.attr` fields to `paths[]`, `sleep_delay`, and `encryption[]`; full `attr` dict still preserved in `other{}`
- Capture `signatures[].desc` and render it in each signature result section
- Fetch `overview.json` to recover configs and signatures missing from behavioral tasks (e.g. Quasar); dedup against behavioral results to avoid double-scoring; rendered in an "Overview" subsection before per-task sections
- Replace the task-level "ATT&CK Techniques" section with per-signature heuristic `attack_ids`, associating each technique with the specific signature and process that triggered it