### PR TITLE
fix: filter unknown sample fields before constructing Sample dataclass

### DIFF
--- a/src/triage_sandbox/report.py
+++ b/src/triage_sandbox/report.py
@@ -1,6 +1,6 @@
 import itertools
 import json
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from datetime import datetime, timedelta
 from ipaddress import ip_address
 from typing import Any, List, Optional, cast
@@ -438,9 +438,16 @@ def _filter_config(cfg: dict) -> dict:  # type: ignore[type-arg]
     return {k: v for k, v in cfg.items() if k in _CONFIG_DATACLASS_FIELDS}
 
 
+def _filter_sample(sample: dict) -> dict:  # type: ignore[type-arg]
+    """Return only keys accepted by the Sample dataclass; drops unknown future Triage sample
+    fields (e.g. user_id) so Sample construction never raises TypeError."""
+    accepted = {f.name for f in fields(Sample)}
+    return {k: v for k, v in sample.items() if k in accepted}
+
+
 class TriageResult:
     def __init__(self, client: TriageClient, sample: dict) -> None:  # type: ignore[type-arg]
-        self.sample = Sample(**sample)
+        self.sample = Sample(**_filter_sample(sample))
         self.sample.get_task_reports(client)
         self.malware_config = list(itertools.chain.from_iterable(r.malware_config for r in self.sample.task_reports))
 

--- a/tests/test_sample_and_result.py
+++ b/tests/test_sample_and_result.py
@@ -342,3 +342,25 @@ def _behavioral_report_no_config(task_id: str) -> dict:
         "dumped": [],
         "tags": [],
     }
+
+
+# ---------------------------------------------------------------------------
+# Regression: unknown Triage sample fields must not crash TriageResult (issue #48)
+# ---------------------------------------------------------------------------
+
+
+def test_triageresult_tolerates_unknown_sample_fields(triage_client, sample_json):
+    """
+    Triage API may add new top-level sample fields (e.g. user_id) that the
+    Sample dataclass doesn't declare.  TriageResult must filter unknown keys
+    before constructing Sample so it never raises TypeError.
+    """
+    import copy
+
+    sample_with_extras = copy.deepcopy(sample_json)
+    sample_with_extras["user_id"] = "u-abc123"  # the field from issue #48
+    sample_with_extras["_future_field"] = "some-value"  # guard against the next one too
+
+    # Must not raise TypeError: Sample.__init__() got an unexpected keyword argument 'user_id'
+    tr = TriageResult(triage_client, sample_with_extras)
+    assert tr.sample.id == sample_json["id"]


### PR DESCRIPTION
Triage's API added a new top-level `user_id` field on sample objects. TriageResult was unpacking the raw dict directly into Sample(**sample), causing TypeError on any field the dataclass doesn't declare.

Add _filter_sample() — parallel to the existing _filter_config() pattern — which drops unknown keys by deriving the accepted set dynamically from dataclasses.fields(Sample). This makes Sample construction tolerant of any future new Triage fields without needing manual updates.

Closes #48